### PR TITLE
Set the color from the current palette by default.

### DIFF
--- a/QProgressIndicator.cpp
+++ b/QProgressIndicator.cpp
@@ -32,7 +32,7 @@ QProgressIndicator::QProgressIndicator(QWidget* parent)
   , m_timerId(-1)
   , m_delay(40)
   , m_displayedWhenStopped(false)
-  , m_color(Qt::black)
+  , m_color(palette().color(QPalette::Normal, QPalette::WindowText))
 {
     setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     setFocusPolicy(Qt::NoFocus);


### PR DESCRIPTION
This improves the default behavior where the palette is a "dark mode" one or the like greatly.